### PR TITLE
HTTPS Support for Heroku

### DIFF
--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -20,3 +20,6 @@ jobs:
           heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
           usedocker: true
+          docker_build_args: GO_ENV
+        env:
+          GO_ENV: production

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,10 @@ FROM alpine:latest AS prod
 # Set working directory for this stage.
 WORKDIR /production
 
+# Set environment variable for production.
+ARG GO_ENV
+ENV GO_ENV ${GO_ENV}
+
 # Run container as a non-root user.
 RUN adduser -D nonroot-container-user
 USER nonroot-container-user

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ yarn lint
 
 There are two ways to run this application **for production**: first is to run with Docker, second is to run this manually. The recommended way is to run this with Docker.
 
+### Manual
+
 - Clone this repository.
 
 ```bash
@@ -72,17 +74,6 @@ cd expert-systems
 
 ```bash
 make test
-```
-
-- If running with Docker, do the following commands and after that, please open `localhost:8080` in your browser or run the provided integration tests with `make e2e`.
-
-```bash
-# Build and start
-docker build . -t expert-systems:latest
-docker run -d -p 8080:8080 expert-systems:latest
-
-# Remove image for cleanup
-docker image rm expert-systems:latest
 ```
 
 - If you want to run this manually, please build React application first.
@@ -107,4 +98,20 @@ make build
 
 ```bash
 make e2e
+```
+
+### Docker
+
+- If running with Docker, do the following commands and after that, please open `localhost:8080` in your browser or run the provided integration tests with `make e2e`.
+
+```bash
+# Build and start
+docker build . -t expert-systems:latest
+docker build . -t expert-systems:latest --build-arg GO_ENV=production # if you want HTTPS with 'X-Forwarded-Proto' header, some services like Heroku use this for HTTPS
+docker run --name expert-systems -d -p 8080:8080 expert-systems:latest
+
+# Remove image for cleanup
+docker stop expert-systems
+docker rm expert-systems
+docker image rm expert-systems:latest
 ```

--- a/cmd/expert-systems/main.go
+++ b/cmd/expert-systems/main.go
@@ -26,10 +26,20 @@ func getPort() string {
 	return fmt.Sprintf(":%s", port)
 }
 
+// Get application mode from environment variable 'GO_ENV'. If it does not exist, use 'development'.
+func getMode() string {
+	mode := os.Getenv("GO_ENV")
+	if mode != "production" {
+		return "development"
+	}
+
+	return "production"
+}
+
 // Starting point, initialize server.
 func main() {
 	// HTTP server initialization.
-	server := &http.Server{Addr: getPort(), Handler: application.Configure(pathToWebDirectory)}
+	server := &http.Server{Addr: getPort(), Handler: application.Configure(pathToWebDirectory, getMode())}
 
 	// Prepare context for graceful shutdown.
 	serverCtx, serverStopCtx := context.WithCancel(context.Background())
@@ -61,7 +71,7 @@ func main() {
 	}()
 
 	// Run our server and print out starting message.
-	log.Printf("Server has started on port %s!", getPort())
+	log.Printf("Server has started on port %s with environment %s!", getPort(), getMode())
 	err := server.ListenAndServe()
 	if err != nil && err != http.ErrServerClosed {
 		log.Fatal(err)


### PR DESCRIPTION
This application is deployed with Heroku. With that in consideration:

- Add HTTPS support for production, will check for `X-Forwarded-Proto`.
- Add environment variable `GO_ENV` in Docker and application. It will be filled with `production` or `development`.
- Tidy up documentation for clearness.